### PR TITLE
Make FSRS_status stay in position when scrolling

### DIFF
--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.13.3 Scheduler Qt6
+// FSRS4Anki v3.13.4 Scheduler Qt6
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -29,12 +29,12 @@ debugger;
 if (display_memory_state) {
     const prev = document.getElementById('FSRS_status')
     if (prev) {prev.remove();}
-    var fsrs_status = document.createElement('div');
+    var fsrs_status = document.createElement('span');
     fsrs_status.innerHTML = "<br>FSRS enabled";
     fsrs_status.id = "FSRS_status";
     fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;";
     document.body.appendChild(fsrs_status);
-    document.getElementById("qa").style.cssText += "min-height:65vh;"
+    document.getElementById("qa").style.cssText += "min-height:50vh;";
 }
 
 // get the name of the card's deck
@@ -280,7 +280,7 @@ function is_empty() {
 }
 
 function set_version() {
-    const version = "3.13.3";
+    const version = "3.13.4";
     customData.again.v = version;
     customData.hard.v = version;
     customData.good.v = version;

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.13.2 Scheduler Qt6
+// FSRS4Anki v3.13.3 Scheduler Qt6
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -279,7 +279,7 @@ function is_empty() {
 }
 
 function set_version() {
-    const version = "3.13.2";
+    const version = "3.13.3";
     customData.again.v = version;
     customData.hard.v = version;
     customData.good.v = version;

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -31,9 +31,10 @@ if (display_memory_state) {
     if (prev) {prev.remove();}
     var fsrs_status = document.createElement('div');
     fsrs_status.innerHTML = "<br>FSRS enabled";
-    fsrs_status.id = "FSRS_status"
-    fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:fixed;bottom:1em;"
+    fsrs_status.id = "FSRS_status";
+    fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;";
     document.body.appendChild(fsrs_status);
+    document.getElementById("qa").style.cssText += "min-height:65vh;"
 }
 
 // get the name of the card's deck

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -32,7 +32,7 @@ if (display_memory_state) {
     var fsrs_status = document.createElement('div');
     fsrs_status.innerHTML = "<br>FSRS enabled";
     fsrs_status.id = "FSRS_status"
-    fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:absolute;bottom:1em;"
+    fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:fixed;bottom:1em;"
     document.body.appendChild(fsrs_status);
 }
 

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -5,6 +5,7 @@ set_version();
 // Default parameters of FSRS4Anki for global
 var w = [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1];
 // The above parameters can be optimized via FSRS4Anki optimizer.
+// For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
 
 // User's custom parameters for global
 let requestRetention = 0.9; // recommended setting: 0.8 ~ 0.9
@@ -18,8 +19,7 @@ let hardInterval = 1.2;
 // sticking together and always coming up for review on the same day
 const enable_fuzz = true;
 
-// The memory state variables calculated by FSRS include Difficulty, Stability, and Retrievability.
-// FSRS supports displaying DSR of reviewing cards before you answer.
+// FSRS supports displaying memory states of cards.
 // Enable it for debugging if you encounter something wrong.
 const display_memory_state = false;
 

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.13.2 Scheduler Qt5
+// FSRS4Anki v3.13.3 Scheduler Qt5
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -268,7 +268,7 @@ function is_empty() {
   return !customData.again.d | !customData.again.s | !customData.hard.d | !customData.hard.s | !customData.good.d | !customData.good.s | !customData.easy.d | !customData.easy.s;
 }
 function set_version() {
-  const version = "3.13.2";
+  const version = "3.13.3";
   customData.again.v = version;
   customData.hard.v = version;
   customData.good.v = version;

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -32,7 +32,7 @@ if (display_memory_state) {
   var fsrs_status = document.createElement('div');
   fsrs_status.innerHTML = "<br>FSRS enabled";
   fsrs_status.id = "FSRS_status";
-  fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:absolute;bottom:1em;";
+  fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:fixed;bottom:1em;";
   document.body.appendChild(fsrs_status);
 }
 

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -32,8 +32,9 @@ if (display_memory_state) {
   var fsrs_status = document.createElement('div');
   fsrs_status.innerHTML = "<br>FSRS enabled";
   fsrs_status.id = "FSRS_status";
-  fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;position:fixed;bottom:1em;";
+  fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;";
   document.body.appendChild(fsrs_status);
+  document.getElementById("qa").style.cssText += "min-height:65vh;"
 }
 
 // get the name of the card's deck

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -5,6 +5,7 @@ set_version();
 // Default parameters of FSRS4Anki for global
 var w = [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1];
 // The above parameters can be optimized via FSRS4Anki optimizer.
+// For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
 
 // User's custom parameters for global
 let requestRetention = 0.9; // recommended setting: 0.8 ~ 0.9
@@ -18,8 +19,7 @@ let hardInterval = 1.2;
 // sticking together and always coming up for review on the same day
 const enable_fuzz = true;
 
-// The memory state variables calculated by FSRS include Difficulty, Stability, and Retrievability.
-// FSRS supports displaying DSR of reviewing cards before you answer.
+// FSRS supports displaying memory states of cards.
 // Enable it for debugging if you encounter something wrong.
 const display_memory_state = false;
 

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.13.3 Scheduler Qt5
+// FSRS4Anki v3.13.4 Scheduler Qt5
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -29,12 +29,12 @@ debugger;
 if (display_memory_state) {
   const prev = document.getElementById('FSRS_status');
   if (prev) {prev.remove();}
-  var fsrs_status = document.createElement('div');
+  var fsrs_status = document.createElement('span');
   fsrs_status.innerHTML = "<br>FSRS enabled";
   fsrs_status.id = "FSRS_status";
   fsrs_status.style.cssText = "font-size:12px;opacity:0.5;font-family:monospace;text-align:left;line-height:1em;";
   document.body.appendChild(fsrs_status);
-  document.getElementById("qa").style.cssText += "min-height:65vh;"
+  document.getElementById("qa").style.cssText += "min-height:50vh;";
 }
 
 // get the name of the card's deck
@@ -269,7 +269,7 @@ function is_empty() {
   return !customData.again.d | !customData.again.s | !customData.hard.d | !customData.hard.s | !customData.good.d | !customData.good.s | !customData.easy.d | !customData.easy.s;
 }
 function set_version() {
-  const version = "3.13.3";
+  const version = "3.13.4";
   customData.again.v = version;
   customData.hard.v = version;
   customData.good.v = version;


### PR DESCRIPTION
A simple change so that the FSRS_status message is always displayed in the bottom left corner, keeping the same distance to the bottom bar, even after scrolling.

On cards that are long enough to scroll, it can incidentally also help with cases where the FSRS_status message and some card text overlap, like here:
![image](https://user-images.githubusercontent.com/52420923/217471039-4a8f7d2a-8e32-4d47-b708-115244357747.png)

I am not able to test or guess whether it is good on Anki Mobile. [edit: Though I could have investigated it on the forum and found [this thread by kleinerpirat](https://forums.ankiweb.net/t/ankimobile-issue-position-fixed-not-working-as-expected-solution/12100).]