### PR TITLE
Sort deckParams by length of deckName before looping through array

### DIFF
--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.14.1 Scheduler Qt6
+// FSRS4Anki v3.14.2 Scheduler Qt6
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -292,7 +292,7 @@ function is_empty() {
   return !customData.again.d | !customData.again.s | !customData.hard.d | !customData.hard.s | !customData.good.d | !customData.good.s | !customData.easy.d | !customData.easy.s;
 }
 function set_version() {
-  const version = "3.14.1";
+  const version = "3.14.2";
   customData.again.v = version;
   customData.hard.v = version;
   customData.good.v = version;

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -59,7 +59,7 @@ const display_memory_state = false;
 debugger;
 // TODO put this code in a better place ↓
 function compareDeckNames(a, b) {
-  // longer names come first, if equal length are ordered alphabetically
+  // longer names come first, if equal length they will be ordered alphabetically
   if (a.deckName.length > b.deckName.length) {
     return -1;
   } else if (a.deckName.length < b.deckName.length) {

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -57,7 +57,24 @@ const display_memory_state = false;
 // Configuration End
 
 debugger;
-
+// TODO put this code in a better place ↓
+function compareDeckNames(a, b) {
+  // longer names come first, if equal length are ordered alphabetically
+  if (a.deckName.length > b.deckName.length) {
+    return -1;
+  } else if (a.deckName.length < b.deckName.length) {
+    return 1;
+  } else {
+    if (a.deckName < b.deckName) {
+      return -1;
+    } else if (a.deckName > b.deckName) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}
+// TODO put this code in a better place ↑
 // display if FSRS is enabled
 if (display_memory_state) {
   const prev = document.getElementById('FSRS_status')
@@ -82,6 +99,7 @@ if (document.getElementById("deck") !== null) {
       return;
     }
   }
+  deckParams.sort(compareDeckNames);
   for (let i = 0; i < deckParams.length; i++) {
     if (deck_name.startsWith(deckParams[i]["deckName"])) {
       params = deckParams[i];

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -73,9 +73,12 @@ let params = {};
 // get the name of the card's deck
 if (document.getElementById("deck") !== null) {
     const deck_name = document.getElementById("deck").getAttribute("deck_name");
+    if (display_memory_state) {
+        fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
+    }
     for (const i of skip_decks) {
         if (deck_name.startsWith(i)) {
-            fsrs_status.innerHTML = "<br>FSRS disabled";
+            fsrs_status.innerHTML = fsrs_status.innerHTML.replace("FSRS enabled", "FSRS disabled");
             return;
         }
     }
@@ -85,8 +88,9 @@ if (document.getElementById("deck") !== null) {
             break;
         }
     }
+} else {
     if (display_memory_state) {
-        fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
+        fsrs_status.innerHTML += "<br>Deck name not found";
     }
 }
 if (Object.keys(params).length === 0) {

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -57,24 +57,7 @@ const display_memory_state = false;
 // Configuration End
 
 debugger;
-// TODO put this code in a better place ↓
-function compareDeckNames(a, b) {
-  // longer names come first, if equal length they will be ordered alphabetically
-  if (a.deckName.length > b.deckName.length) {
-    return -1;
-  } else if (a.deckName.length < b.deckName.length) {
-    return 1;
-  } else {
-    if (a.deckName < b.deckName) {
-      return -1;
-    } else if (a.deckName > b.deckName) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
-}
-// TODO put this code in a better place ↑
+
 // display if FSRS is enabled
 if (display_memory_state) {
   const prev = document.getElementById('FSRS_status')
@@ -99,7 +82,10 @@ if (document.getElementById("deck") !== null) {
       return;
     }
   }
-  deckParams.sort(compareDeckNames);
+  // Arrange the deckParams of sub-decks in front of their parent decks.
+  deckParams.sort(function(a, b) {
+    return -a.deckName.localeCompare(b.deckName);
+  });
   for (let i = 0; i < deckParams.length; i++) {
     if (deck_name.startsWith(deckParams[i]["deckName"])) {
       params = deckParams[i];

--- a/fsrs4anki_scheduler.js
+++ b/fsrs4anki_scheduler.js
@@ -1,19 +1,49 @@
-// FSRS4Anki v3.13.4 Scheduler Qt6
+// FSRS4Anki v3.14.0 Scheduler Qt6
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
-// Default parameters of FSRS4Anki for global
-var w = [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1];
-// The above parameters can be optimized via FSRS4Anki optimizer.
-// For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
+// Configuration Start
 
-// User's custom parameters for global
-let requestRetention = 0.9; // recommended setting: 0.8 ~ 0.9
-let maximumInterval = 36500;
-let easyBonus = 1.3;
-let hardInterval = 1.2;
-// FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
-// I recommend setting steps shorter than 1 day.
+const deckParams = [
+    {
+        // Default parameters of FSRS4Anki for global
+        "deckName": "global config for FSRS4Anki",
+        "w": [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1],
+        // The above parameters can be optimized via FSRS4Anki optimizer.
+        // For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
+        // User's custom parameters for global
+        "requestRetention": 0.9, // recommended setting: 0.8 ~ 0.9
+        "maximumInterval": 36500,
+        "easyBonus": 1.3,
+        "hardInterval": 1.2,
+        // FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
+        // I recommend setting steps shorter than 1 day.
+    },
+    {
+        "deckName": "ALL::Learning::English::Reading",
+        // User's custom parameters for the specific deck
+        // need to add <div id=deck deck_name="{{Deck}}"></div> to your card's front template's first line
+        "w": [1.1475, 1.401, 5.1483, -1.4221, -1.2282, 0.035, 1.4668, -0.1286, 0.7539, 1.9671, -0.2307, 0.32, 0.9451],
+        "requestRetention": 0.9,
+        "maximumInterval": 36500,
+        "easyBonus": 1.3,
+        "hardInterval": 1.2,
+        // User's custom parameters for this deck and all sub-decks
+    },
+    {
+        "deckName": "ALL::Archive",
+        "w": [1.2879, 0.5135, 4.9532, -1.502, -1.0922, 0.0081, 1.3771, -0.0294, 0.6718, 1.8335, -0.4066, 0.7291, 0.5517],
+        "requestRetention": 0.9,
+        "maximumInterval": 36500,
+        "easyBonus": 1.3,
+        "hardInterval": 1.2,
+        // User's custom parameters for this deck and all sub-decks
+    }
+];
+
+// To turn off FSRS in specific decks, fill them into the skip_decks list below.
+// Please don't remove it even if you don't need it.
+const skip_decks = ["ALL::Learning::ML::NNDL", "ALL::Learning::English"];
 
 // "Fuzz" is a small random delay applied to new intervals to prevent cards from
 // sticking together and always coming up for review on the same day
@@ -22,6 +52,8 @@ const enable_fuzz = true;
 // FSRS supports displaying memory states of cards.
 // Enable it for debugging if you encounter something wrong.
 const display_memory_state = false;
+
+// Configuration End
 
 debugger;
 
@@ -37,54 +69,44 @@ if (display_memory_state) {
     document.getElementById("qa").style.cssText += "min-height:50vh;";
 }
 
+let params = {};
 // get the name of the card's deck
-// need to add <div id=deck deck_name="{{Deck}}"></div> to your card's front template's first line
 if (document.getElementById("deck") !== null) {
     const deck_name = document.getElementById("deck").getAttribute("deck_name");
-    // parameters for a specific deck
-    if (deck_name == "ALL::Learning::English::Reading") {
-        var w = [1.1475, 1.401, 5.1483, -1.4221, -1.2282, 0.035, 1.4668, -0.1286, 0.7539, 1.9671, -0.2307, 0.32, 0.9451];
-        // User's custom parameters for the specific deck
-        requestRetention = 0.9;
-        maximumInterval = 36500;
-        easyBonus = 1.3;
-        hardInterval = 1.2;
-    // parameters for a deck's all sub-decks
-    } else if (deck_name.startsWith("ALL::Archive")) {
-        var w = [1.2879, 0.5135, 4.9532, -1.502, -1.0922, 0.0081, 1.3771, -0.0294, 0.6718, 1.8335, -0.4066, 0.7291, 0.5517];
-        // User's custom parameters for sub-decks
-        requestRetention = 0.9;
-        maximumInterval = 36500;
-        easyBonus = 1.3;
-        hardInterval = 1.2;
-    }
-    // To turn off FSRS in specific decks, fill them into the skip_decks list below.
-    // Please don't remove it even if you don't need it.
-    const skip_decks = ["ALL::Learning::ML::NNDL", "ALL::Learning::English"];
     for (const i of skip_decks) {
         if (deck_name.startsWith(i)) {
             fsrs_status.innerHTML = "<br>FSRS disabled";
-            return ;
+            return;
         }
     }
-
-    if(display_memory_state) {
+    for (let i = 0; i < deckParams.length; i++) {
+        if (deck_name.startsWith(deckParams[i]["deckName"])) {
+            params = deckParams[i];
+            break;
+        }
+    }
+    if (display_memory_state) {
         fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
     }
 }
-
+if (Object.keys(params).length === 0) {
+    params = deckParams.find(deck => deck.deckName === "global config for FSRS4Anki");
+}
+var w = params["w"];
+var requestRetention = params["requestRetention"];
+var maximumInterval = params["maximumInterval"];
+var easyBonus = params["easyBonus"];
+var hardInterval = params["hardInterval"];
 // auto-calculate intervalModifier
 const intervalModifier = Math.log(requestRetention) / Math.log(0.9);
 // global fuzz factor for all ratings.
 const fuzz_factor = set_fuzz_factor();
-
 const ratings = {
   "again": 1,
   "hard": 2,
   "good": 3,
   "easy": 4
 };
-
 // For new cards
 if (is_new()) {
     init_states();

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -2,6 +2,8 @@
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
+// Configuration Start
+
 const deckParams = [
   {
     // Default parameters of FSRS4Anki for global
@@ -20,12 +22,13 @@ const deckParams = [
   {
     "deckName": "ALL::Learning::English::Reading",
     // User's custom parameters for the specific deck
+    // need to add <div id=deck deck_name="{{Deck}}"></div> to your card's front template's first line
     "w": [1.1475, 1.401, 5.1483, -1.4221, -1.2282, 0.035, 1.4668, -0.1286, 0.7539, 1.9671, -0.2307, 0.32, 0.9451],
     "requestRetention": 0.9,
     "maximumInterval": 36500,
     "easyBonus": 1.3,
     "hardInterval": 1.2,
-    // User's custom parameters for only this deck
+    // User's custom parameters for this deck and all sub-decks
   },
   {
     "deckName": "ALL::Archive",
@@ -50,6 +53,8 @@ const enable_fuzz = true;
 // Enable it for debugging if you encounter something wrong.
 const display_memory_state = false;
 
+// Configuration End
+
 debugger;
 
 // display if FSRS is enabled
@@ -64,38 +69,34 @@ if (display_memory_state) {
   document.getElementById("qa").style.cssText += "min-height:50vh;";
 }
 
+let params = {};
 // get the name of the card's deck
-// need to add <div id=deck deck_name="{{Deck}}"></div> to your card's front template's first line
 if (document.getElementById("deck") !== null) {
   const deck_name = document.getElementById("deck").getAttribute("deck_name");
-  let params = {};
-
-  for (let i = 0; i < deckParams.length; i++) {
-	  if (deck_name.startsWith(deckParams[i]["deckName"])) {
-	  	params = deckParams[i];
-		  break;
-	  }
-  }
-  if (Object.keys(params).length === 0) {
-    params = deckParams.find(deck => deck.deckName === "global config for FSRS4Anki");
-  }
-  var w = params["w"];
-  var requestRetention = params["requestRetention"];
-  var maximumInterval = params["maximumInterval"];
-  var easyBonus = params["easyBonus"];
-  var hardInterval = params["hardInterval"];
-
   for (const i of skip_decks) {
     if (deck_name.startsWith(i)) {
       fsrs_status.innerHTML = "<br>FSRS disabled";
       return;
     }
   }
+  for (let i = 0; i < deckParams.length; i++) {
+    if (deck_name.startsWith(deckParams[i]["deckName"])) {
+      params = deckParams[i];
+      break;
+    }
+  }
   if (display_memory_state) {
     fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
   }
 }
-
+if (Object.keys(params).length === 0) {
+  params = deckParams.find(deck => deck.deckName === "global config for FSRS4Anki");
+}
+const w = params["w"];
+const requestRetention = params["requestRetention"];
+const maximumInterval = params["maximumInterval"];
+const easyBonus = params["easyBonus"];
+const hardInterval = params["hardInterval"];
 // auto-calculate intervalModifier
 const intervalModifier = Math.log(requestRetention) / Math.log(0.9);
 // global fuzz factor for all ratings.

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -73,7 +73,7 @@ if (document.getElementById("deck") !== null) {
   for (let i = 0; i < deckParams.length; i++) {
 	  if (deck_name.startsWith(deckParams[i]["deckName"])) {
 	  	params = deckParams[i];
-		  break;
+		break;
 	  }
   }
   if (Object.keys(params).length === 0) {

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -42,10 +42,7 @@ const deckParams = [
 
 // To turn off FSRS in specific decks, fill them into the skip_decks list below.
 // Please don't remove it even if you don't need it.
-const skip_decks [
-	"ALL::Learning::ML::NNDL",
-	"ALL::Learning::English"
-	];
+const skip_decks = ["ALL::Learning::ML::NNDL", "ALL::Learning::English"];
 
 // "Fuzz" is a small random delay applied to new intervals to prevent cards from
 // sticking together and always coming up for review on the same day

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.13.4 Scheduler Qt5
+// FSRS4Anki v3.14.0 Scheduler Qt5
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -14,7 +14,6 @@ const deckParams = [
     "maximumInterval": 36500,
     "easyBonus": 1.3,
     "hardInterval": 1.2,
-    "includeSubdecks?": true,
     // FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
     // I recommend setting steps shorter than 1 day.
   },
@@ -26,7 +25,6 @@ const deckParams = [
     "maximumInterval": 36500,
     "easyBonus": 1.3,
     "hardInterval": 1.2,
-    "includeSubdecks?": false
     // User's custom parameters for only this deck
   },
   {
@@ -36,7 +34,6 @@ const deckParams = [
     "maximumInterval": 36500,
     "easyBonus": 1.3,
     "hardInterval": 1.2,
-    "includeSubdecks?": true
     // User's custom parameters for this deck and all sub-decks
   }
 ];
@@ -74,17 +71,10 @@ if (document.getElementById("deck") !== null) {
   let params = {};
 
   for (let i = 0; i < deckParams.length; i++) {
-	if (deckParams[i]["includeSubdecks?"] === true) {
 	  if (deck_name.startsWith(deckParams[i]["deckName"])) {
 	  	params = deckParams[i];
-		break;
+		  break;
 	  }
-	} else {
-      if (deck_name === deckParams[i]["deckName"]) {
-        params = deckParams[i];
-        break;
-      }
-	}
   }
   if (Object.keys(params).length === 0) {
     params = deckParams.find(deck => deck.deckName === "global config for FSRS4Anki");

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -2,18 +2,50 @@
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
-// Default parameters of FSRS4Anki for global
-var w = [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1];
-// The above parameters can be optimized via FSRS4Anki optimizer.
-// For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
+const deckParams = [
+  {
+    // Default parameters of FSRS4Anki for global
+    "deckName": "global config for FSRS4Anki",
+    "w": [1, 1, 5, -0.5, -0.5, 0.2, 1.4, -0.12, 0.8, 2, -0.2, 0.2, 1],
+    // The above parameters can be optimized via FSRS4Anki optimizer.
+    // For details about the parameters, please see: https://github.com/open-spaced-repetition/fsrs4anki/wiki/Free-Spaced-Repetition-Scheduler
+    // User's custom parameters for global
+    "requestRetention": 0.9, // recommended setting: 0.8 ~ 0.9
+    "maximumInterval": 36500,
+    "easyBonus": 1.3,
+    "hardInterval": 1.2
+    // FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
+    // I recommend setting steps shorter than 1 day.
+  },
+  {
+    "deckName": "ALL::Learning::English::Reading",
+    // User's custom parameters for the specific deck
+    "w": [1.1475, 1.401, 5.1483, -1.4221, -1.2282, 0.035, 1.4668, -0.1286, 0.7539, 1.9671, -0.2307, 0.32, 0.9451],
+    "requestRetention": 0.9,
+    "maximumInterval": 36500,
+    "easyBonus": 1.3,
+    "hardInterval": 1.2,
+    "includeSubdecks?": false
+    // User's custom parameters for only this deck
+  },
+  {
+    "deckName": "ALL::Archive",
+    "w": [1.2879, 0.5135, 4.9532, -1.502, -1.0922, 0.0081, 1.3771, -0.0294, 0.6718, 1.8335, -0.4066, 0.7291, 0.5517],
+    "requestRetention": 0.9,
+    "maximumInterval": 36500,
+    "easyBonus": 1.3,
+    "hardInterval": 1.2,
+    "includeSubdecks?": true
+    // User's custom parameters for this deck and all sub-decks
+  }
+];
 
-// User's custom parameters for global
-let requestRetention = 0.9; // recommended setting: 0.8 ~ 0.9
-let maximumInterval = 36500;
-let easyBonus = 1.3;
-let hardInterval = 1.2;
-// FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
-// I recommend setting steps shorter than 1 day.
+// To turn off FSRS in specific decks, fill them into the skip_decks list below.
+// Please don't remove it even if you don't need it.
+const skip_decks [
+	"ALL::Learning::ML::NNDL",
+	"ALL::Learning::English"
+	];
 
 // "Fuzz" is a small random delay applied to new intervals to prevent cards from
 // sticking together and always coming up for review on the same day
@@ -41,26 +73,30 @@ if (display_memory_state) {
 // need to add <div id=deck deck_name="{{Deck}}"></div> to your card's front template's first line
 if (document.getElementById("deck") !== null) {
   const deck_name = document.getElementById("deck").getAttribute("deck_name");
-  // parameters for a specific deck
-  if (deck_name == "ALL::Learning::English::Reading") {
-    var w = [1.1475, 1.401, 5.1483, -1.4221, -1.2282, 0.035, 1.4668, -0.1286, 0.7539, 1.9671, -0.2307, 0.32, 0.9451];
-    // User's custom parameters for the specific deck
-    requestRetention = 0.9;
-    maximumInterval = 36500;
-    easyBonus = 1.3;
-    hardInterval = 1.2;
-    // parameters for a deck's all sub-decks
-  } else if (deck_name.startsWith("ALL::Archive")) {
-    var w = [1.2879, 0.5135, 4.9532, -1.502, -1.0922, 0.0081, 1.3771, -0.0294, 0.6718, 1.8335, -0.4066, 0.7291, 0.5517];
-    // User's custom parameters for sub-decks
-    requestRetention = 0.9;
-    maximumInterval = 36500;
-    easyBonus = 1.3;
-    hardInterval = 1.2;
+  let params = {};
+
+  for (let i = 0; i < deckParams.length; i++) {
+	if (deckParams[i]["includeSubdecks?"] === true) {
+	  if (deck_name.startsWith(deckParams[i]["deckName"])) {
+	  	params = deckParams[i];
+		break;
+	  }
+	} else {
+      if (deck_name === deckParams[i]["deckName"]) {
+        params = deckParams[i];
+        break;
+      }
+	}
   }
-  // To turn off FSRS in specific decks, fill them into the skip_decks list below.
-  // Please don't remove it even if you don't need it.
-  const skip_decks = ["ALL::Learning::ML::NNDL", "ALL::Learning::English"];
+  if (Object.keys(params).length === 0) {
+    params = deckParams.find(deck => deck.deckName === "global config for FSRS4Anki");
+  }
+  var w = params["w"];
+  var requestRetention = params["requestRetention"];
+  var maximumInterval = params["maximumInterval"];
+  var easyBonus = params["easyBonus"];
+  var hardInterval = params["hardInterval"];
+
   for (const i of skip_decks) {
     if (deck_name.startsWith(i)) {
       fsrs_status.innerHTML = "<br>FSRS disabled";

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -1,4 +1,4 @@
-// FSRS4Anki v3.14.1 Scheduler Qt5
+// FSRS4Anki v3.14.2 Scheduler Qt5
 set_version();
 // The latest version will be released on https://github.com/open-spaced-repetition/fsrs4anki
 
@@ -82,6 +82,10 @@ if (document.getElementById("deck") !== null) {
       return;
     }
   }
+  // Arrange the deckParams of sub-decks in front of their parent decks.
+  deckParams.sort(function(a, b) {
+    return -a.deckName.localeCompare(b.deckName);
+  });
   for (let i = 0; i < deckParams.length; i++) {
     if (deck_name.startsWith(deckParams[i]["deckName"])) {
       params = deckParams[i];
@@ -298,7 +302,7 @@ function is_empty() {
   return !customData.again.d | !customData.again.s | !customData.hard.d | !customData.hard.s | !customData.good.d | !customData.good.s | !customData.easy.d | !customData.easy.s;
 }
 function set_version() {
-  const version = "3.14.1";
+  const version = "3.14.2";
   customData.again.v = version;
   customData.hard.v = version;
   customData.good.v = version;

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -73,9 +73,12 @@ let params = {};
 // get the name of the card's deck
 if (document.getElementById("deck") !== null) {
   const deck_name = document.getElementById("deck").getAttribute("deck_name");
+  if (display_memory_state) {
+    fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
+  }
   for (const i of skip_decks) {
     if (deck_name.startsWith(i)) {
-      fsrs_status.innerHTML = "<br>FSRS disabled";
+      fsrs_status.innerHTML = fsrs_status.innerHTML.replace("FSRS enabled", "FSRS disabled");
       return;
     }
   }
@@ -85,8 +88,9 @@ if (document.getElementById("deck") !== null) {
       break;
     }
   }
+} else {
   if (display_memory_state) {
-    fsrs_status.innerHTML += "<br>Deck name: " + deck_name;
+    fsrs_status.innerHTML += "<br>Deck name not found";
   }
 }
 if (Object.keys(params).length === 0) {

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -13,7 +13,8 @@ const deckParams = [
     "requestRetention": 0.9, // recommended setting: 0.8 ~ 0.9
     "maximumInterval": 36500,
     "easyBonus": 1.3,
-    "hardInterval": 1.2
+    "hardInterval": 1.2,
+    "includeSubdecks?": true,
     // FSRS only modifies the long-term scheduling. So (re)learning steps in deck options work as usual.
     // I recommend setting steps shorter than 1 day.
   },

--- a/fsrs4anki_scheduler_qt5.js
+++ b/fsrs4anki_scheduler_qt5.js
@@ -73,7 +73,7 @@ if (document.getElementById("deck") !== null) {
   for (let i = 0; i < deckParams.length; i++) {
 	  if (deck_name.startsWith(deckParams[i]["deckName"])) {
 	  	params = deckParams[i];
-		break;
+		  break;
 	  }
   }
   if (Object.keys(params).length === 0) {


### PR DESCRIPTION
Minimal code for issue #168 

tested with an [online compiler](https://www.programiz.com/javascript/online-compiler/)  and seemed to work

    const deckParams = [
      {"deckName":"bbb"},
      {"deckName":"aaaa"},
      {"deckName":"cc"},
      {"deckName":"aabb"},
      {"deckName":"ccc"},
    ];
    
    function compareDeckNames(a, b) {
      // longer names come first, if equal length they will be ordered alphabetically
      if (a.deckName.length > b.deckName.length) {
        return -1;
      } else if (a.deckName.length < b.deckName.length) {
        return 1;
      } else {
        if (a.deckName < b.deckName) {
          return -1;
        } else if (a.deckName > b.deckName) {
          return 1;
        } else {
          return 0;
        }
      }
    }
    
    deckParams.sort(compareDeckNames);
    
    console.log(deckParams);

P.S.: It was just 1 commit I made but it is appearing as 11 commits. I don't know what is the issue...